### PR TITLE
Require database for loader.bat command

### DIFF
--- a/Loader.bat
+++ b/Loader.bat
@@ -1,10 +1,7 @@
 rem sets the PGADMIN password
 set PGPASSWORD=geografio
 
-rem automatically assigns the appropriate directory
-
 rem run psql
-"C:\Program Files\PostgreSQL\9.6\bin\psql.exe" -U postgres -f craters.sql  
-"C:\Program Files\PostgreSQL\9.6\bin\psql.exe" -U postgres -f IAU2000.sql
-
-
+"C:\Program Files\PostgreSQL\9.6\bin\psql.exe" -U postgres -c "CREATE DATABASE %1;" 
+"C:\Program Files\PostgreSQL\9.6\bin\psql.exe" -U postgres -f craters.sql -d %1  
+"C:\Program Files\PostgreSQL\9.6\bin\psql.exe" -U postgres -f IAU2000.sql -d %1


### PR DESCRIPTION
Require entry of the database name to the load.bat command.  For example:

C:\loader.bat mydb